### PR TITLE
Production fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,10 @@
         "nsis"
       ]
     },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true
+    },
     "linux": {
       "target": [
         "AppImage"


### PR DESCRIPTION
This pull request introduces a small configuration change to the Windows installer settings in `package.json`. The change allows users to choose the installation directory and disables one-click installation for Windows builds.

* Windows installer configuration:
  * [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R89-R92): Added `nsis` configuration to disable one-click installation and enable changing the installation directory.