### PR TITLE
Fixed-[Bug] In settings page issue #9

### DIFF
--- a/src/renderer/components/AdminPanel/AdminSettingsModal.tsx
+++ b/src/renderer/components/AdminPanel/AdminSettingsModal.tsx
@@ -56,6 +56,8 @@ export default function AdminSettingsModal({
 
   useEffect(() => {
     if (isOpen) {
+      setActiveTab('Account');
+      setSearchQuery('');
       setNewTeamName(user?.teamName || '');
       setEditingName(false);
       setNameError('');

--- a/src/renderer/components/Settings/SettingsModal.tsx
+++ b/src/renderer/components/Settings/SettingsModal.tsx
@@ -94,6 +94,14 @@ export default function SettingsModal({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
 
+  // Reset active tab to default when modal is opened
+  useEffect(() => {
+    if (isOpen) {
+      setActiveTab("Text Editor");
+      setSearchQuery("");
+    }
+  }, [isOpen]);
+
   // Refresh activity log when opening the modal or switching to the Activity Log tab
   useEffect(() => {
     if (


### PR DESCRIPTION
In the admin settings panel the app get the last selected settings tab as the default selected tab after we close and reopen the settings panel. I fixed it to get the top tab as the default tab.