### PR TITLE
Fixed-[Bug] Preview panel not syncing when changing workspace folder #23

### DIFF
--- a/src/renderer/components/Editor/EditorPanel.tsx
+++ b/src/renderer/components/Editor/EditorPanel.tsx
@@ -452,6 +452,7 @@ const EditorPanel = React.memo(function EditorPanel({
           >
             {tab.type === "preview" ? (
               <PreviewPanel
+                key={workspaceRoot || 'empty'}
                 workspaceRoot={workspaceRoot}
                 activeFilePath={activeFilePath}
                 initialUrl={previewInitialUrl}

--- a/src/renderer/components/Preview/PreviewPanel.tsx
+++ b/src/renderer/components/Preview/PreviewPanel.tsx
@@ -151,7 +151,7 @@ export default function PreviewPanel({ workspaceRoot, activeFilePath, initialUrl
       wv.removeEventListener('console-message', onConsoleMessage);
       wv.removeEventListener('dom-ready', onDomReady);
     };
-  }, [serverUrl]);
+  }, [serverUrl, initialUrl]);
 
   useEffect(() => {
     const handleFileSaved = () => {

--- a/src/renderer/pages/IDE.tsx
+++ b/src/renderer/pages/IDE.tsx
@@ -994,6 +994,10 @@ function IDEContent() {
     null,
   );
 
+  useEffect(() => {
+    setPreviewInitialUrl(null);
+  }, [workspaceRoot]);
+
   const openPreviewInTab = useCallback(
     (urlFromPanel?: string) => {
       const previewPath = "__preview__";
@@ -1149,6 +1153,7 @@ function IDEContent() {
               <PanelResizeHandle className="resize-handle" />
               <Panel id="preview" order={3} defaultSize={20} minSize={15}>
                 <PreviewPanel
+                  key={workspaceRoot || 'empty'}
                   workspaceRoot={workspaceRoot}
                   activeFilePath={activeTabPath}
                   onOpenInTab={openPreviewInTab}


### PR DESCRIPTION
This pull request addresses issues with preview panel behavior when switching workspaces, ensuring the preview panel resets correctly and updates its dependencies. The changes focus on improving the stability and correctness of the preview panel and its interactions with workspace changes.

